### PR TITLE
add: AppBrickie CI to make build testing easier

### DIFF
--- a/.github/workflows/app-brickie.yaml
+++ b/.github/workflows/app-brickie.yaml
@@ -1,0 +1,23 @@
+name: AppBrickieBuilder
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: App Brickie
+    steps:
+      - uses: actions/checkout@v2
+      - name: AppBrickie
+        id: appBrickieBuild
+        uses: DarthBenro008/app-brickie@v3.1
+        with:
+          type: "native"
+          chatid: "c5c5dug538ds725c9lb0"
+          packagename: "GitPositive"
+      - name: Get Automated Result
+        run: echo "${{ steps.appBrickieBuild.outputs.result }}"


### PR DESCRIPTION
Adds the [AppBrickieCI](https://github.com/DarthBenro008/app-brickie) to this repo which makes it easier for maintainers

Features:
- Automated builds to telegram with each PR raised
- One tap installation to check the PR
- No need to cheery-pick and build manually