### PR TITLE
added repositories screen dark mode

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\vivek\.android\avd\Pixel_4_API_30_2.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2021-10-04T10:13:24.772411200Z" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,6 +6,9 @@
         <entry key="..\:/GitHub Repositry/Hacktoberfest/gitpositive/app/src/main/res/layout/activity_main.xml" value="0.23645833333333333" />
         <entry key="..\:/GitHub Repositry/Hacktoberfest/gitpositive/app/src/main/res/layout/activity_splash.xml" value="0.23645833333333333" />
         <entry key="..\:/GitHub Repositry/Hacktoberfest/gitpositive/app/src/main/res/layout/loading_dialog.xml" value="0.23645833333333333" />
+        <entry key="..\:/HacktoberFest2021/gitpositive/app/src/main/res/layout/activity_main.xml" value="0.25416666666666665" />
+        <entry key="..\:/HacktoberFest2021/gitpositive/app/src/main/res/layout/activity_splash.xml" value="0.25416666666666665" />
+        <entry key="..\:/HacktoberFest2021/gitpositive/app/src/main/res/layout/loading_dialog.xml" value="0.25416666666666665" />
         <entry key="..\:/Users/praso/AndroidStudioProjects/gitpositive/app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.2388888888888889" />
         <entry key="..\:/Users/praso/AndroidStudioProjects/gitpositive/app/src/main/res/drawable/border.xml" value="0.2388888888888889" />
         <entry key="..\:/Users/praso/AndroidStudioProjects/gitpositive/app/src/main/res/drawable/circle.xml" value="0.2388888888888889" />

--- a/app/src/main/java/org/acmvit/gitpositive/repositoryList/ui/RepositoryActivity.kt
+++ b/app/src/main/java/org/acmvit/gitpositive/repositoryList/ui/RepositoryActivity.kt
@@ -1,9 +1,12 @@
 package org.acmvit.gitpositive.repositoryList.ui
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -24,8 +27,6 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
 import org.acmvit.gitpositive.repositoryList.model.RepositoryResponseItem
 import org.acmvit.gitpositive.repositoryList.viewmodel.RepositoryViewModel
-import android.content.Intent
-import android.net.Uri
 
 
 @AndroidEntryPoint
@@ -56,7 +57,7 @@ fun RepositoryListScreen(viewModel: RepositoryViewModel, onItemClick: (String) -
     val list by remember {
         viewModel.repoList
     }
-    Surface {
+    Surface(color = if (isSystemInDarkTheme()) Color(0xFF000000) else Color(0xFFFFFFFF)) {
         LazyColumn {
             items(list) { item ->
                 SingleRepoItem(item) { onItemClick(it) }
@@ -78,7 +79,9 @@ fun SingleRepoItem(
                 onClick(item.html_url)
             },
         shape = RoundedCornerShape(12.dp),
-        elevation = 6.dp
+        elevation = 6.dp,
+        contentColor = if (isSystemInDarkTheme()) Color(0xFFE6E6E6) else Color(0xFF1C1C1C),
+        backgroundColor = if (isSystemInDarkTheme()) Color(0xFF212121) else Color(0xFFFFFFFF)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(


### PR DESCRIPTION
Hey @gaganmalvi 👋🏼 
I saw issue #26 regarding `dark mode` to be implemented in the `Repositories Screen` when we apply dark mode in our device as a whole
I saw the code of the person assigned to it, but he directly applied the dark mode colors, which will result in `Repositories Screen` always in dark mode and does not change to light mode when we switch mode of the system

So, I proposing the code for the desired thing that you guys want
Take a look and review the code by checking it on your device

Thanks